### PR TITLE
Resolve resource from getClass() instead of getSystemResourceAsStream()

### DIFF
--- a/src/com/studiohartman/jamepad/ControllerManager.java
+++ b/src/com/studiohartman/jamepad/ControllerManager.java
@@ -38,7 +38,7 @@ public class ControllerManager {
      * https://github.com/gabomdq/SDL_GameControllerDB
      */
     public ControllerManager() {
-        this(4, "gamecontrollerdb.txt");
+        this(4, "/gamecontrollerdb.txt");
     }
 
     /**
@@ -47,7 +47,7 @@ public class ControllerManager {
      * @param maxNumControllers The number of controllers this ControllerManager can deal with
      */
     public ControllerManager(int maxNumControllers) {
-        this(maxNumControllers, "gamecontrollerdb.txt");
+        this(maxNumControllers, "/gamecontrollerdb.txt");
     }
 
     /**
@@ -288,7 +288,7 @@ public class ControllerManager {
         most people would use this library.
          */
         Path extractedLoc = FileSystems.getDefault().getPath(System.getProperty("java.io.tmpdir"), path);
-        Files.copy(ClassLoader.getSystemResourceAsStream(path), extractedLoc,
+        Files.copy(getClass().getResourceAsStream(path), extractedLoc,
                 StandardCopyOption.REPLACE_EXISTING);
 
         if(!nativeAddMappingsFromFile(extractedLoc.toString())) {


### PR DESCRIPTION
I'm using this great library in a Spring boot application in conjunction with JavaFX. The gamepad support is working great when I start the application from the IDE, in this case Intellij. However, when I package the jar and run it from command line (e.g. `mvn package && java -jar target/app.jar`), it fails during the creation of the `ControllerManager`.

```java
this.controllerManager = new ControllerManager();
this.controllerManager.initSDLGamepad(); // this line fails
```

Here is the partial stack trace:

```
Caused by: java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Objects.java:203) ~[na:1.8.0_144]
	at java.nio.file.Files.copy(Files.java:2984) ~[na:1.8.0_144]
	at com.studiohartman.jamepad.ControllerManager.addMappingsFromFile(ControllerManager.java:291) ~[Jamepad-1.1.jar!/:na]
	at com.studiohartman.jamepad.ControllerManager.initSDLGamepad(ControllerManager.java:88) ~[Jamepad-1.1.jar!/:na]
	at de.schrieveslaach.effective.nlp.application.development.qpt.input.Gamepad.<init>(Gamepad.java:55) ~[classes!/:1.0-SNAPSHOT]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_144]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_144]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_144]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_144]
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:142) ~[spring-beans-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
	... 25 common frames omitted
```

I looked into the details and it turns out that `ClassLoader.getSystemResourceAsStream(path)` is not able to resolve resources from the JAR which has been packaged by the Spring boot maven plugin. I think it is due to the fact that Spring boot uses a custom class loader which won't be used by `ClassLoader.getSystemResourceAsStream(path)`. Therefore, this PR changes the library to use the correct class loader