### PR TITLE
Fixed default mappingsPath in ControllerManager

### DIFF
--- a/src/com/studiohartman/jamepad/ControllerManager.java
+++ b/src/com/studiohartman/jamepad/ControllerManager.java
@@ -39,7 +39,7 @@ public class ControllerManager {
      * https://github.com/gabomdq/SDL_GameControllerDB
      */
     public ControllerManager() {
-        this(4, "gamecontrollerdb.txt");
+        this(4, "/gamecontrollerdb.txt");
     }
 
     /**
@@ -48,7 +48,7 @@ public class ControllerManager {
      * @param maxNumControllers The number of controllers this ControllerManager can deal with
      */
     public ControllerManager(int maxNumControllers) {
-        this(maxNumControllers, "gamecontrollerdb.txt");
+        this(maxNumControllers, "/gamecontrollerdb.txt");
     }
 
     /**


### PR DESCRIPTION
Hey Will,

This pull request updates the default `mappingsPath` in `ControllerManager` to use an absolute file path.

Without this change, the call to `getClass().getResourceAsStream` on [Line 306](https://github.com/williamahartman/Jamepad/blob/1.3.1/src/com/studiohartman/jamepad/ControllerManager.java#L306) attempts to load `/com/studiohartman/jamepad/gamecontrollerdb.txt`, which doesn't exist.

In my Maven project, both the `getClass().getResourceAsStream` call and the fallback `ClassLoader.getSystemResourceAsStream` call were failing to load the default `gamecontrollerdb.txt` resource, but using an absolute path resolves the issue.